### PR TITLE
Stub-gl feature for testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ image-io = ["image"] # Additional image functionality, for example loading an im
 obj-io = ["wavefront_obj", "image-io"]
 phong-renderer = [] # Phong forward and deferred renderer.
 debug = [] # Prints OpenGL debug information (only available when NOT building for the wasm32 architecture)
+stub-gl = [] # Allows to initialize a stub three-d context, without OpenGL for testing
 
 [dependencies]
 log = "0.4"

--- a/src/camera/camera.rs
+++ b/src/camera/camera.rs
@@ -2,7 +2,8 @@ use crate::core::*;
 use crate::definition::*;
 use crate::math::*;
 
-pub(super) enum ProjectionType {
+#[derive(PartialEq, Debug)]
+pub enum ProjectionType {
     Orthographic {
         width: f32,
         height: f32,
@@ -341,7 +342,7 @@ impl Camera {
         (self.screen2ray * screen_pos).truncate().normalize()
     }
 
-    pub(super) fn projection_type(&self) -> &ProjectionType {
+    pub fn projection_type(&self) -> &ProjectionType {
         &self.projection_type
     }
 


### PR DESCRIPTION
This PR adds a "stub-gl" cargo feature, to optionally compile three-d with a stubbed opengl context.

Also, the ProjectionType of the camera is made public and comparable for testing.